### PR TITLE
chore: update QuickStart guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Gnoland is a robust blockchain that provides concurrency and scalability with sm
 
 ## Tutorials
 
-* [Quickstart Guide](https://gno.land/r/boards:gnolang/4) - How to start interacting with the blockchain.
+* [Quickstart Guide](https://test2.gno.land/r/boards:testboard/5) - How to start interacting with the blockchain.
 * [A Beginner’s Guide to the Gnoland Testnet](https://medium.com/@onbloc/a-beginners-guide-to-the-gnoland-testnet-6fdc693a48f4) - A visual guide to creating a wallet and receiving $GNOTs on the testnet.
 * [Gnolang Basics](https://github.com/moul/gno-basics) - Simple examples of Gnolang contracts.
 


### PR DESCRIPTION
This is not a new link just a fix for one that doesn't seem to resolve as intended.

Quickstart Guide used to go to: https://gno.land/r/boards:gnolang/4
Now goes to: https://test2.gno.land/r/boards:testboard/5

Which is where I was able to find what I believe is the intended content.