### PR TITLE
feat: add gnoland.cn

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Gnoland is a robust blockchain that provides concurrency and scalability with sm
 * [Hello Gno!](https://github.com/xplrz/gnoland-workshop) - Step by step workshop to learn Gnolang and Gnoland features.
 * [Gnoland Developer Portal](https://github.com/onbloc/gnoland-tutorials) - All-in-one place for Gnoland developers, providing introductions, tutorials with detailed examples, and developer resources.
 * [Gno Smart Contract Demo](https://www.youtube.com/watch?v=-BlnEXCs0eI) - A short video tutorial on writing and deploying a simple Realm and Package.
+* [Gno Chinese Station](https://www.gnoland.cn) - A website for Chinese Developers, providing tutorials, documents, and gno news.
 
 ## Social
 


### PR DESCRIPTION
A website for Chinese Gno developers.
Providing: 
- Introductions and tutorials
- Base API documents (work in progress)
- Gno News (work in progress)

[https://www.gnoland.cn](https://www.gnoland.cn)