### PR TITLE
feat: add link to `supernova`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+.vscode
+.idea

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Gnoland is a robust blockchain that provides concurrency and scalability with sm
 * [Keplr Integration](https://github.com/gnolang/gno/pull/154) - WIP Integration with the Keplr browser extension.
 * [Gnoscan](http://gnoscan.io/) - Gnoscan is a Gnoland blockchain explorer, making on-chain data legible and intuitive for everyone.
 * [Gno Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=harry-hov.gno) - Rich Gno/Gnolang support for Visual Studio Code.
+* [Supernova](https://github.com/gnolang/supernova) - Stress testing tool for the Gno Tendermint2 blockchain.
 
 ## Tutorials
 


### PR DESCRIPTION
## Description

This PR adds a link to the Gno TM2 stress-testing tool [supernova](https://github.com/gnolang/supernova).
Additionally, it also adds a small `.gitignore` file.