### PR TITLE
Failing In Public + Setup & First Realm On Ubuntu Added To ## Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Gnoland is a robust blockchain that provides concurrency and scalability with sm
 * [Gnoland Developer Portal](https://github.com/onbloc/gnoland-tutorials) - All-in-one place for Gnoland developers, providing introductions, tutorials with detailed examples, and developer resources.
 * [Gno Smart Contract Demo](https://www.youtube.com/watch?v=-BlnEXCs0eI) - A short video tutorial on writing and deploying a simple Realm and Package.
 * [Gno Chinese Station](https://www.gnoland.cn) - A website for Chinese Developers, providing tutorials, documents, and gno news.
+* [Failing In Public](https://proggr.hashnode.dev/gnoland-initial-experience-gonzo-take-on-failing-in-public) - A gonzo journalist take on first gno/CosmosSDK experiences.
+* [Setup & First Realm On Ubuntu](https://proggr.hashnode.dev/gnoland-localnet-walkthrough-first-realm-on-ubuntu) - Local installation & realm deployment on Ubuntu.
 
 ## SDKs & Clients
 


### PR DESCRIPTION
Intended Failing In Public to be more straight walkthrough, but instead leaned into chasing leads and capturing the exploration once the "faucet fail" changed direction. Hair longer than intended, and less tutorial, more how not to do things from a noob's/EVM devs eyes. 

Setup & First Realm digests what was learned in the gonzo take to successfully interact with boards, and makes a `bar20` token to walk through deploying a new realm.