### PR TITLE
feat: add `gno-mode` for emacs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Gnoland is a robust blockchain that provides concurrency and scalability with sm
 * [Gnoscan](http://gnoscan.io/) - Gnoscan is a Gnoland blockchain explorer, making on-chain data legible and intuitive for everyone.
 * [Gno Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=harry-hov.gno) - Rich Gno/Gnolang support for Visual Studio Code.
 * [Supernova](https://github.com/gnolang/supernova) - Stress testing tool for the Gno Tendermint2 blockchain.
+* [Gno-mode for Emacs](https://gist.github.com/gfanton/6e233656dfeabd7a46f21f7507b6b311) - Major mode for editing GNO files in Emacs, based on go-mode. Work in progress.
 
 ## Tutorials
 


### PR DESCRIPTION
This pull request adds a link to `gno-mode`, a major mode for editing `GNO` files in Emacs. 
It's a work-in-progress mode based on go-mode, with only minor differences for now:
- Adaptation for formatting GNO code using gofumpt.
- Temporary disabling of the Language Server Protocol (LSP) for GNO files, as it creates conflicts and doesn't work with GNO files.