### PR TITLE
chore: use the Github version of the Boards realm tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Gnoland is a robust blockchain that provides concurrency and scalability with sm
 
 * [Getting Started](https://github.com/gnolang/getting-started) - Get started with your first Gnolang Realm easily with this repo.
 * [Gno By Example](https://gno-by-example.com) - Tutorials and code snippets for learning Gnolang.
-* [Quickstart Guide](https://test2.gno.land/r/boards:testboard/5) - How to start interacting with the blockchain.
+* [Quickstart Guide](https://github.com/gnolang/gno/blob/master/examples/gno.land/r/demo/boards/README.md) - How to start interacting with the blockchain.
 * [A Beginner’s Guide to the Gnoland Testnet](https://medium.com/@onbloc/a-beginners-guide-to-the-gnoland-testnet-6fdc693a48f4) - A visual guide to creating a wallet and receiving $GNOTs on the testnet.
 * [Gnolang 101](https://github.com/onbloc/gnolang-101) - A course designed for aspiring smart-contract developers on Gnoland.
 * [Gnolang Basics](https://github.com/moul/gno-basics) - Simple examples of Gnolang contracts.


### PR DESCRIPTION
We already merged PR https://github.com/gnolang/gno/pull/1049 for the READMEs in the gno repo. This pull request does the same for this README which uses an outdated version of the Board Realm tutorial. Now, we use the Github tutorial instead of the one on the testnet chain.