### PR TITLE
feat: add Gno for Sublime Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Gnoland is a robust blockchain that provides concurrency and scalability with sm
 * [Gno Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=harry-hov.gno) - Rich Gno/Gnolang support for Visual Studio Code.
 * [Supernova](https://github.com/gnolang/supernova) - Stress testing tool for the Gno Tendermint2 blockchain.
 * [Gno-mode for Emacs](https://gist.github.com/gfanton/6e233656dfeabd7a46f21f7507b6b311) - Major mode for editing GNO files in Emacs, based on go-mode. Work in progress.
+* [Gno for Sublime Text](https://github.com/jdkato/gno-sublime-text) - Gno syntax highlighting for Sublime Text.
 
 ## Tutorials
 


### PR DESCRIPTION
This adds the [Gno package](https://packagecontrol.io/packages/Gno) for Sublime Text, which brings syntax highlighting for `.gno` files.

It's also a dependency for using the `gnols` Language Server, which I'll add in another PR (once I improve its documentation).

