### PR TITLE
Add 2 games written in GNO

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ _Resources to help you understand how to get around gno.land and use Gno._
 - [Gno Chinese Station](https://www.gnoland.cn) - A website for Chinese developers, providing tutorials, resources, and Gno news.
 - [Failing In Public](https://proggr.hashnode.dev/gnoland-initial-experience-gonzo-take-on-failing-in-public) - A gonzo journalist take on first gno/CosmosSDK experiences.
 - ["go -> gno" presentation](https://github.com/gnolang/workshops/tree/main/presentations/2023-06-26--go-to-gno--schollz) - "Things I wish I knew when I started out with Gno, when coming from a Go background" by Zack Scholl.
+- [Cap'n Cluck's Tic-tac-toe](https://greps.gnAsteroid.com/r/grepsuzette/games/tictactoe) - A tic-tac-toe with UI written in gno, running on an asteroid.
+- [Underwater Minesweeper](https://greps.gnAsteroid.com/r/grepsuzette/games/minesweeper) - Underwater Minesweeper, written in gno. No Js, just GNO+HTML+CSS. A classic productivity game for the office.
 
 ## SDKs & Clients
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ _Resources to help you understand how to get around gno.land and use Gno._
 - [Failing In Public](https://proggr.hashnode.dev/gnoland-initial-experience-gonzo-take-on-failing-in-public) - A gonzo journalist take on first gno/CosmosSDK experiences.
 - ["go -> gno" presentation](https://github.com/gnolang/workshops/tree/main/presentations/2023-06-26--go-to-gno--schollz) - "Things I wish I knew when I started out with Gno, when coming from a Go background" by Zack Scholl.
 - [Cap'n Cluck's Tic-tac-toe](https://greps.gnAsteroid.com/r/grepsuzette/games/tictactoe) - A tic-tac-toe with UI written in gno, running on an asteroid.
-- [Underwater Minesweeper](https://greps.gnAsteroid.com/r/grepsuzette/games/minesweeper) - Underwater Minesweeper, written in gno. No Js, just GNO+HTML+CSS. A classic productivity game for the office.
+- [Underwater Minesweeper](https://greps.gnAsteroid.com/r/grepsuzette/games/minesweeper) - A classic office-productivity game, written in gno with no JS — just GNO+HTML+CSS.
 
 ## SDKs & Clients
 


### PR DESCRIPTION
They run on greps' asteroid. They don't need a wallet and run without js. 

Currently the asteroids and those 2 games are run from test4, because it's waiting for https://github.com/gnolang/gno/pull/2554 to be merged to Portal loop. 

Nevertheless both games are playable, the code on test4 is visible. Also those URLs will not change, so should be good to add.