### PR TITLE
Add GnoWatch: a validator signing  tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ _Tools useful for developing in Gno._
 
 _Tools useful for monitoring in Gno._
 
-- [Gnoland_validator_signing](https://github.com/RaulBernal/Gnoland_validator_monitoring) - Is your Validator signing blocks right now? Get alerts via Telegram if it isn't.
+- [GnoWatch:_a validator_signing tool](https://github.com/RaulBernal/GnoWatch) - Is your Validator signing blocks right now? Get alerts via Telegram if it isn't.
 
 ## Tutorials, Presentations, Resources
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ _Tools useful for developing in Gno._
 
 _Tools useful for monitoring in Gno._
 
-- [GnoWatch:_a validator_signing tool](https://github.com/RaulBernal/GnoWatch) - Is your Validator signing blocks right now? Get alerts via Telegram if it isn't.
+- [GnoWatch: a validator signing tool](https://github.com/RaulBernal/GnoWatch) - Is your Validator signing blocks right now? Get alerts via Telegram if it isn't.
 
 ## Tutorials, Presentations, Resources
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ _Tools useful for developing in Gno._
 - [:GnoFileTest command for vim](https://gist.github.com/grepsuzette/66f5cfaccc1a919c67f52bd7b31a3b09) - `:GnoFileTest` snippet for vim
 - [gno.nvim](https://github.com/x1unix/gno.nvim) - Gno language support for NeoVim.
 
+## Monitoring
+
+_Tools useful for monitoring in Gno._
+
+- [Gnoland_validator_signing](https://github.com/RaulBernal/Gnoland_validator_monitoring) - Is your Validator signing blocks right now? Get alerts via Telegram if it isn't.
+
 ## Tutorials, Presentations, Resources
 
 _Resources to help you understand how to get around gno.land and use Gno._


### PR DESCRIPTION
This is a small but powerful monitoring tool for validator nodes on the Gno.Land network.

It's awesome because:

It doesn't need to run on the validator node.
It provides simple but effective alerts via Telegram.
It doesn't monitor the node itself, but rather the result of a signed block on the blockchain.
It can monitor one or multiple validators.
It's production-tested: the AviaOne validator uses it.