### PR TITLE
Add gnopls

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ _Tools useful for developing in Gno._
 - [Gno for Sublime Text](https://github.com/jdkato/gno-sublime-text) - Gno syntax highlighting for Sublime Text.
 - [:GnoFileTest command for vim](https://gist.github.com/grepsuzette/66f5cfaccc1a919c67f52bd7b31a3b09) - `:GnoFileTest` snippet for vim
 - [gno.nvim](https://github.com/x1unix/gno.nvim) - Gno language support for NeoVim.
+- [gnopls](https://github.com/gnoverse/gnopls) - A language server providing editor features like autocompletion, hover, and go-to-definition.
 
 ## Tutorials, Presentations, Resources
 


### PR DESCRIPTION
Adds [gnopls](https://github.com/gnoverse/gnopls), the Gno Language Server, to the **Tools** section.

### Why it's awesome
The Tools section already lists several editor integrations (VS Code, Emacs, Sublime, vim, NeoVim), but the underlying language server that powers editor features was missing. gnopls provides autocompletion, hover, and go-to-definition, and is the backend many of these editor setups rely on. It fills a real gap in the list.

### Checklist
- [x] One link per PR
- [x] PR title format `Add project-name`
- [x] Description is short and ends with a period
- [x] Added under the correct section (Tools)
- [x] No trailing whitespace on the added line
- [x] Verified the link is live