### PR TITLE
Add mygnoscan

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ _Tools useful for developing in Gno._
 - [gnobro](https://github.com/gnolang/gno/tree/master/contribs/gnobro) - A terminal UI for browsing and exploring Gno realms, with real-time gnodev integration via WebSocket.
 - [gnovanity](https://github.com/gnoverse/gnovanity) - A command-line tool for generating vanity wallet addresses.
 - [gnockpit](https://github.com/gnoverse/gnockpit) - A real-time web dashboard for monitoring validator node health.
+- [mygnoscan](https://github.com/gnoverse/mygnoscan) - A fast, minimal block explorer with realm dependency graphs and usage tracking.
 
 ## Tutorials, Presentations, Resources
 


### PR DESCRIPTION
Adds [`gnoverse/mygnoscan`](https://github.com/gnoverse/mygnoscan) to the **Tools** section.

```markdown
- [mygnoscan](https://github.com/gnoverse/mygnoscan) - A fast, minimal block explorer with realm dependency graphs and usage tracking.
```

Part of a batch adding gnoverse tooling + moul's gno projects (one link per PR, per CONTRIBUTING.md). Best merged after #73 (the awesome-lint + link-check CI / README cleanup); a rebase on the updated `main` will be needed to pick up the lint-clean base.
