### PR TITLE
Add gnit

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ _Connecting web2 to the gno.land blockchain._
 _Collections of gno packages providing generic functionality which developers can extend with custom code to create applications._
 
 - [daokit](https://github.com/samouraiworld/gnodaokit) - Create DAOs that can mirror real-world organizations.
+- [gnit](https://github.com/gnoverse/gnit) - A composable Git protocol package that lets any realm act as a Git repository.
 
 ## Socials
 


### PR DESCRIPTION
Adds [`gnoverse/gnit`](https://github.com/gnoverse/gnit) to the **Frameworks** section.

```markdown
- [gnit](https://github.com/gnoverse/gnit) - A composable Git protocol package that lets any realm act as a Git repository.
```

Part of a batch adding gnoverse tooling + moul's gno projects (one link per PR, per CONTRIBUTING.md). Best merged after #73 (the awesome-lint + link-check CI / README cleanup); a rebase on the updated `main` will be needed to pick up the lint-clean base.
