### PR TITLE
Add dSocial

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ _Apps developed by the gno.land community._
 - [Gnolove](https://gnolove.world) - Community leaderboard and contributions analytics for builders of the Gnoland ecosystem.
 - [Zenao](https://zenao.io) - Organize events in seconds then build your resilient community & social organizations.
 - [Gnomputer](https://github.com/moul/gnomputer) - A windowed web workstation for browsing realms, source, and live chain activity.
+- [dSocial](https://github.com/gnoverse/dsocial) - Experimental social apps, tools, and dApps.
 
 ## Tools
 


### PR DESCRIPTION
Adds [`gnoverse/dsocial`](https://github.com/gnoverse/dsocial) to the **Community Apps** section.

```markdown
- [dSocial](https://github.com/gnoverse/dsocial) - Experimental social apps, tools, and dApps.
```

Part of a batch adding gnoverse tooling + moul's gno projects (one link per PR, per CONTRIBUTING.md). Best merged after #73 (the awesome-lint + link-check CI / README cleanup); a rebase on the updated `main` will be needed to pick up the lint-clean base.
