### PR TITLE
Add Gnomputer

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ _Apps developed by the gno.land community._
 - [Adena Wallet](https://adena.app/) - Friendly wallet that simplifies sending & receiving tokens, staking, NFT storage, and dapp connections.
 - [Gnolove](https://gnolove.world) - Community leaderboard and contributions analytics for builders of the Gnoland ecosystem.
 - [Zenao](https://zenao.io) - Organize events in seconds then build your resilient community & social organizations.
+- [Gnomputer](https://github.com/moul/gnomputer) - A windowed web workstation for browsing realms, source, and live chain activity.
 
 ## Tools
 


### PR DESCRIPTION
Adds [`moul/gnomputer`](https://github.com/moul/gnomputer) to the **Community Apps** section.

```markdown
- [Gnomputer](https://github.com/moul/gnomputer) - A windowed web workstation for browsing realms, source, and live chain activity.
```

Part of a batch adding gnoverse tooling + moul's gno projects (one link per PR, per CONTRIBUTING.md). Best merged after #73 (the awesome-lint + link-check CI / README cleanup); a rebase on the updated `main` will be needed to pick up the lint-clean base.
