### PR TITLE
Add gno-contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ _Resources to help you understand how to get around gno.land and use Gno._
 - [Gno Chinese Station](https://www.gnoland.cn) - A website for Chinese developers, providing tutorials, resources, and Gno news.
 - [Failing In Public](https://proggr.hashnode.dev/gnoland-initial-experience-gonzo-take-on-failing-in-public) - A gonzo journalist take on first gno/CosmosSDK experiences.
 - ["go -> gno" presentation](https://github.com/gnolang/workshops/tree/main/presentations/2023-06-26--go-to-gno--schollz) - "Things I wish I knew when I started out with Gno, when coming from a Go background" by Zack Scholl.
+- [gno-contracts](https://github.com/moul/gno-contracts) - A versioned, self-contained collection of example realms and packages, tested against gno master.
 
 ## SDKs & Clients
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ _Resources to help you understand how to get around gno.land and use Gno._
 - [Gno Chinese Station](https://www.gnoland.cn) - A website for Chinese developers, providing tutorials, resources, and Gno news.
 - [Failing In Public](https://proggr.hashnode.dev/gnoland-initial-experience-gonzo-take-on-failing-in-public) - A gonzo journalist take on first gno/CosmosSDK experiences.
 - ["go -> gno" presentation](https://github.com/gnolang/workshops/tree/main/presentations/2023-06-26--go-to-gno--schollz) - "Things I wish I knew when I started out with Gno, when coming from a Go background" by Zack Scholl.
-- [gno-contracts](https://github.com/moul/gno-contracts) - A versioned, self-contained collection of example realms and packages, tested against gno master.
+- [gno-contracts](https://github.com/moul/gno-contracts) - moul's collection of 20+ versioned, self-contained gno.land packages and realms, tested against gno master.
 
 ## SDKs & Clients
 


### PR DESCRIPTION
Adds [`moul/gno-contracts`](https://github.com/moul/gno-contracts) to the **Tutorials, Presentations, Resources** section.

```markdown
- [gno-contracts](https://github.com/moul/gno-contracts) - moul's collection of 20+ versioned, self-contained gno.land packages and realms, tested against gno master.
```

Part of a batch adding gnoverse tooling + moul's gno projects (one link per PR, per CONTRIBUTING.md). Best merged after #73 (the awesome-lint + link-check CI / README cleanup); a rebase on the updated `main` will be needed to pick up the lint-clean base.

_Note: the collection is still being populated from open PRs on gno-contracts; merge this once it's genuinely 20+._
