### PR TITLE
Add gnockpit

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ _Tools useful for developing in Gno._
 - [gno-mcp](https://github.com/gnoverse/gno-mcp) - An MCP server and agent skill connecting realms to AI coding assistants like Claude, Cursor, and Gemini CLI.
 - [gnobro](https://github.com/gnolang/gno/tree/master/contribs/gnobro) - A terminal UI for browsing and exploring Gno realms, with real-time gnodev integration via WebSocket.
 - [gnovanity](https://github.com/gnoverse/gnovanity) - A command-line tool for generating vanity wallet addresses.
+- [gnockpit](https://github.com/gnoverse/gnockpit) - A real-time web dashboard for monitoring validator node health.
 
 ## Tutorials, Presentations, Resources
 


### PR DESCRIPTION
Adds [`gnoverse/gnockpit`](https://github.com/gnoverse/gnockpit) to the **Tools** section.

```markdown
- [gnockpit](https://github.com/gnoverse/gnockpit) - A real-time web dashboard for monitoring validator node health.
```

> [!NOTE]
> `gnoverse/gnockpit` is currently a **private** repo, so the `link-check` job will be **red** (404) until it's made public. That's expected — awesome-lint passes, and the link will resolve once the repo is public. Hold merge until then.