### PR TITLE
ci: make CI resilient — merge=union for README + ignore ephemeral testnet URLs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# The list is append-heavy: almost every PR adds a bullet to the end of a
+# section, so two open PRs routinely collide on the same lines of README.md.
+#
+# `merge=union` tells git (and GitHub's merge/"update branch" machinery) to keep
+# the lines from BOTH sides of a three-way merge instead of raising a conflict.
+# For an additive list that means two PRs each adding an entry just both land —
+# no manual conflict resolution, no rebase churn.
+#
+# Safety net: the awesome-lint job (double-link, list-item, toc rules) and the
+# link-check job still run on the merged result, so a duplicate or malformed
+# entry that a union merge might introduce is caught in CI rather than shipped.
+README.md merge=union

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,8 +1,11 @@
 # Decommissioned / rolling gno.land testnets.
-# These are listed for historical reference (Archive section) and testnet
-# endpoints are torn down as new ones ship, so they must not fail CI.
+# Testnet endpoints are inherently ephemeral — they're torn down as new ones
+# ship (test5 -> ... -> test13 -> topaz -> ...), so their liveness must not gate
+# CI. Which testnet is "current" is kept accurate via normal content PRs, not by
+# link-checking. This covers every *.testnets.gno.land host (test13, topaz,
+# rpc.*, future named ones) plus the older testN.gno.land archive entries.
+https?://([a-z0-9-]+\.)*testnets\.gno\.land/?
 https?://test[0-9]+\.gno\.land/?
-https?://rpc\.test[0-9]+\.testnets\.gno\.land/?
 
 # Chinese community site, intermittently unreachable from CI runners.
 https?://(www\.)?gnoland\.cn/?


### PR DESCRIPTION
Two changes that make CI stop fighting us — one for merge conflicts, one for testnet link rot.

## 1. `merge=union` on `README.md` (`.gitattributes`)
Every entry PR appends to the same sections of one `README.md`, so any two open PRs — or a PR vs. a freshly-merged `main` — collide on the same lines. That's the main source of rebase churn.

The built-in **union** merge driver makes git (and GitHub's merge / "Update branch" machinery, which honors `.gitattributes`) keep the lines from **both** sides of a three-way merge instead of raising a conflict. Two PRs each adding an entry now both just land.

**Verified locally:** two branches each appending a different bullet to `## Tools`, merged → `0` conflict markers, both entries present. Without the attribute the same merge conflicts.

Safe because it only changes *merge* behavior; `awesome-lint` (double-link / list-item / toc) and `link-check` still run on the result, so a dup/malformed entry is caught in CI. Union won't resolve two edits to the *same existing line* (rare here) — those still conflict, correctly.

## 2. Ignore ephemeral `*.testnets.gno.land` in link-check (`.lycheeignore`)
Testnets rotate constantly (`test5 → … → test13 → topaz → …`). The moment one is decommissioned its link 404s and breaks link-check for **every** open PR — which just happened: `test13.testnets.gno.land` went down as `topaz` took over, turning `main`'s link-check red repo-wide. Testnet *liveness* shouldn't gate CI; which testnet is current is kept accurate via normal content PRs (e.g. #95). The ignore now covers the whole `*.testnets.gno.land` family (test13, topaz, `rpc.*`, future named ones).

## Further options (not in this PR — for discussion)
1. **Enable auto-merge + a merge queue** so approved PRs land promptly instead of drifting out of date.
2. **Drop "require branch up to date before merge"** if enabled — it forces a rebase on every intervening merge (the churn we're killing); `merge=union` + a queue removes the need.
3. **Structural (biggest win):** move entries to per-entry data files (`data/<section>/<name>.yaml`) and generate `README.md`. Two PRs adding different entries then touch *different files* → conflict impossible. This is the direction of #58.