### PR TITLE
Add Peer Dev Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ _Resources to help you understand how to get around gno.land and use Gno._
 - [Failing In Public](https://proggr.hashnode.dev/gnoland-initial-experience-gonzo-take-on-failing-in-public) - A gonzo journalist take on first gno/CosmosSDK experiences.
 - ["go -> gno" presentation](https://github.com/gnolang/workshops/tree/main/presentations/2023-06-26--go-to-gno--schollz) - "Things I wish I knew when I started out with Gno, when coming from a Go background" by Zack Scholl.
 - [gno-contracts](https://github.com/moul/gno-contracts) - A collection of 50+ versioned, self-contained gno.land packages and realms by moul, tested against gno master.
+- [Peer Dev Learning](https://www.youtube.com/playlist?list=PLJZrQikyfMc-kBojXgAojOz4UQPuq4DiY) - A YouTube playlist of gno.land development tutorials by Peer Dev.
 
 ## SDKs & Clients
 


### PR DESCRIPTION
Adds the Peer Dev Learning gno.land tutorials playlist to Tutorials, Presentations, Resources.

Linked to the gno.land playlist rather than the whole channel, since the channel also covers other chains; this keeps the entry gno-focused. Resolves the follow-up from #69.
