### PR TITLE
Add tx-exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,4 +169,5 @@ _Older, outdated, or archived items._
 - [test3.gno.land](https://test3.gno.land/) - Third official testnet environment (archive).
 - [test2.gno.land](https://test2.gno.land/) - Second official testnet environment (archive).
 - [test1.gno.land](https://test1.gno.land/) - First official testnet environment (archive).
+- [tx-exports](https://github.com/gnolang/tx-exports) - Archived transaction data from past and present gno.land networks (gnoland1, staging, topaz, and the test1-test13 testnets).
 - [Hello Gno!](https://github.com/xplrz/gnoland-workshop) - A step-by-step workshop on Gno and gno.land's main features.


### PR DESCRIPTION
Adds gnolang/tx-exports to the Archive section.

It holds the archived transaction data for past and present gno.land networks (gnoland1, staging, topaz, and the test1-test13 testnets), so it belongs alongside the archived testnet entries.
